### PR TITLE
Patch interface

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ Metrics/LineLength:
     - rohbau.gemspec
     - examples/**/*.rb
 
+Metrics/ModuleLength:
+  Exclude:
+    - lib/rohbau/shared_specs/default_gateway.rb
+
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 

--- a/lib/rohbau/interface.rb
+++ b/lib/rohbau/interface.rb
@@ -73,15 +73,11 @@ module Rohbau
       use_case = args[0]
       input = args[1] || {}
       call_use_case(domain, use_case, input)
-    rescue NameError => e
-      msg = "You tried to call a use case from the #{domain} domain, " \
-        "but the following error occured: #{e.inspect}"
-      raise msg
     end
 
     class Caller
       def initialize(domain)
-        @domain = domain
+        @domain = validate_and_return!(domain)
       end
 
       def call(use_case, args, options = {})
@@ -120,6 +116,16 @@ module Rohbau
         [domain, :UseCases, use_case].inject(Object) do |ns, const|
           ns.const_get(const)
         end
+      end
+
+      def validate_and_return!(domain)
+        return domain if Object.const_defined?(domain)
+        raise ArgumentError, missing_domain_message(domain)
+      end
+
+      def missing_domain_message(domain)
+        "You tried to call a use case from the #{domain}, but that domain " \
+        "does not exist."
       end
 
       def domain

--- a/lib/rohbau/version.rb
+++ b/lib/rohbau/version.rb
@@ -1,3 +1,3 @@
 module Rohbau
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -35,7 +35,7 @@ describe Rohbau::Interface do
   end
 
   it 'raises if the domain is unknown' do
-    assert_raises RuntimeError do
+    assert_raises ArgumentError do
       interface.really_fake_domain :equally_fake_use_case
     end
   end


### PR DESCRIPTION
Fix an issue in interface which caused all NoMethodErrors to be caught and raised with unhelpful messages.  Bump version to 0.2.1
